### PR TITLE
fix old guild commands issue

### DIFF
--- a/bot/discord/src/jvmMain/kotlin/io/github/sophon/discord/DiscordBot.kt
+++ b/bot/discord/src/jvmMain/kotlin/io/github/sophon/discord/DiscordBot.kt
@@ -126,7 +126,7 @@ internal class DiscordBotImpl(
         Napier.e(tag = TAG) { "⚠️ Login ended (bot disconnected)" }
     }
 
-    private suspend fun cleanOldGuildCommands(kord: Kord) {
+    private suspend fun cleanOldGuildCommands(kord: Kord) = try {
         val testGuildSnowFlake = Snowflake(adminConfig.adminServerId)
         kord.getGuildApplicationCommands(testGuildSnowFlake).collect { command ->
             try {
@@ -135,6 +135,8 @@ internal class DiscordBotImpl(
                 Napier.e(tag = TAG) { "Failed to delete command ${command.name}: ${e.message}" }
             }
         }
+    } catch(e: Exception) {
+        Napier.e(tag = TAG, throwable = e) { "Failed to delete old commands" }
     }
 
     private suspend fun MessageCreateEvent.handleMessage() {

--- a/bot/discord/src/jvmMain/kotlin/io/github/sophon/discord/main.kt
+++ b/bot/discord/src/jvmMain/kotlin/io/github/sophon/discord/main.kt
@@ -91,7 +91,7 @@ private fun getApiKey(): String {
     // fall back to config file (for local development)
     val configFile = File(CONFIG_FILE_NAME)
     if (configFile.exists().not()) {
-        throw IllegalStateException("No API key found. Set DISCORD_API_KEY env var or create $CONFIG_FILE_NAME")
+        throw IllegalStateException("No API key found. Set $ENV_API_DISCORD env var or create $CONFIG_FILE_NAME")
     }
 
     val json = Json {


### PR DESCRIPTION
- surround everything in `cleanOldGuildCommands` in additional try/catch 
- fixing a naming discrepancy i noticed during testing 

Testing: 
- `./gradlew :bot:discord:fatJar`
- `java -jar ./bot/discord/build/libs/discord-bot-all.jar` no longer throws exception on startup, bot appears online in my test server 

new error logged but this time ultimately ignored: 

```
SEVERE: [ERROR] DiscordBot - Failed to delete old commands
dev.kord.rest.request.KtorRequestException: REST request returned an error: 403 Forbidden  Missing Access null
        at dev.kord.rest.request.KtorRequestHandler.handle(KtorRequestHandler.kt:60)
        at dev.kord.rest.request.KtorRequestHandler$handle$1.invokeSuspend(KtorRequestHandler.kt)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:829)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
```